### PR TITLE
adding Page Not Found for all non defined routes

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,4 +100,9 @@ app.post(`/api/phonenumbers/parse/file/`, upload.single('myFile'), async (reques
         response.status(400).json("No file recieved");
     }
 });
+
+app.get('*', (req, res) =>{
+    res.status(404).send("<h2>The Page you looking for is not found. <br/>Error: 404</h2>");
+})
+
 module.exports = app;


### PR DESCRIPTION
I have added a simple function to catch all HTTP-GET requests to your web-service that have not been defined. And output a standard 404 error.